### PR TITLE
(1) Rename 'Ausgang' and 'Bussgeldbescheid

### DIFF
--- a/erzwingungshaft-eai/src/main/java/de/muenchen/eh/claim/efile/operation/contentbuilder/OutgoingRequestDTOBuilder.java
+++ b/erzwingungshaft-eai/src/main/java/de/muenchen/eh/claim/efile/operation/contentbuilder/OutgoingRequestDTOBuilder.java
@@ -37,7 +37,7 @@ public class OutgoingRequestDTOBuilder {
 
         assert fineFileReference.getObjid() != null;
         params.put("referrednumber", fineFileReference.getObjid());
-        params.put("filesubj", fineProperties.getFilesubj());
+        params.put("filesubj", contentWrapper.getClaimImport().getKassenzeichen());
         params.put("objterms",
                 (contentWrapper.getClaimImport().getGeschaeftspartnerId().concat(";").concat(contentWrapper.getClaimImport().getKassenzeichen())));
         params.put("accdef", fineProperties.getAccdef());
@@ -45,7 +45,7 @@ public class OutgoingRequestDTOBuilder {
         params.put("outgoingdate", OffsetDateTimeFormatter.formatNow());
 
         params.put("incattachments", fineProperties.getIncattachments());
-        params.put("shortname", fineProperties.getOutgoing());
+        params.put("shortname", fineProperties.getOutgoing().concat(" ").concat(contentWrapper.getClaimImport().getGeschaeftspartnerId()));
 
         return params;
     }

--- a/erzwingungshaft-eai/src/main/java/de/muenchen/eh/claim/efile/properties/FineProperties.java
+++ b/erzwingungshaft-eai/src/main/java/de/muenchen/eh/claim/efile/properties/FineProperties.java
@@ -9,7 +9,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class FineProperties {
 
     private String shortname;
-    private String filesubj;
     private String accdef;
     private String doctemplate;
     private String subfiletype;

--- a/erzwingungshaft-eai/src/test/resources/application-test.yml
+++ b/erzwingungshaft-eai/src/test/resources/application-test.yml
@@ -66,9 +66,9 @@ efile:
       gp-birth-date: BusinessDataGPBirthDate
   fine:
     shortname: Bussgeldverfahren
-    filesubj: Bussgeldbescheid
+#    filesubj: Bussgeldbescheid
     accdef: 'Zugriffsdefinition für Schriftgutobjekte (allgemein lesbar)'
-    outgoing: Ausgang
+    outgoing: EH-Antrag
     doctemplate: 'LHM Schreiben Extern'
     subfiletype: PDF-Dokument
     incattachments: EH-Dokumente


### PR DESCRIPTION
Efile : (1) Rename 'Ausgang' to 'EH-Antrag <GpId>'. (2) Rename 'Bussgeldbescheid' to <Kassenzeichen>

# Pull Request

<!-- Links -->
[code-quality-link]: https://erzwingungshaft.oss.muenchen.de/templates/develop#code-quality
[erzwingungshaft-create-issue-link]: https://github.com/it-at-m/erzwingungshaft/issues/new/choose
[erzwingungshaft-create-documentation-issue-link]: https://github.com/it-at-m/erzwingungshaft/issues/new?template=4-documentation-change.yml

## Changes

- Rename 'Ausgang' to 'EH-Antrag <GpId>'
- Rename 'Bussgeldbescheid' to <Kassenzeichen>

## Reference

Issue: ABLUESKVU-451



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified request parameter construction to source data from alternative configuration sources
  * Restructured configuration property handling for improved consistency

* **Tests**
  * Updated test configuration and data to align with parameter sourcing changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->